### PR TITLE
Update prepare.R

### DIFF
--- a/R/prepare.R
+++ b/R/prepare.R
@@ -527,7 +527,7 @@ readIDATDNAmethylation <- function(files,
 
   # for eah file move it to upper parent folder
   plyr::a_ply(files, 1,function(x){
-    tryCatch(TCGAbiolinks:::move(x,file.path(dirname(dirname(x)), basename(x)),keep.copy = TRUE),error = function(e){})
+    tryCatch(TCGAbiolinks:::move(x,file.path(dirname(dirname(x)), basename(x)),keep.copy = FALSE),error = function(e){})
   })
 
   samples <- unique(gsub("_Grn.idat|_Red.idat","",moved.files))


### PR DESCRIPTION
Currently, when running GDCprepare on IDAT files, the data is being duplicated because not only we are moving the individual .idat files but also keeping their original copy. Making keep.copy=FALSE fixes this.