### PR TITLE
Update prepare.R

### DIFF
--- a/R/prepare.R
+++ b/R/prepare.R
@@ -525,12 +525,20 @@ readIDATDNAmethylation <- function(files,
     stop("sesame package is needed for this function to work. Please install it.",
          call. = FALSE)
   }
-
-  moved.files <- file.path(dirname(dirname(files)), basename(files))
-
-  # for eah file move it to upper parent folder
+  
+  # Check if moved files would be moved outside of scope folder, if so, path doesn't change
+  moved.files <- sapply(files,USE.NAMES=FALSE,function(x){
+    if(grepl("Raw_intensities",dirname(dirname(x)))){
+      return(file.path(dirname(dirname(x)), basename(x)))
+    }
+    return(x)
+  })
+  
+  # for each file move it to upper parent folder if necessary
   plyr::a_ply(files, 1,function(x){
-    tryCatch(TCGAbiolinks:::move(x,file.path(dirname(dirname(x)), basename(x)),keep.copy = FALSE),error = function(e){})
+    if(grepl("Raw_intensities",dirname(dirname(x)))){
+      tryCatch(TCGAbiolinks:::move(x,file.path(dirname(dirname(x)), basename(x)),keep.copy = FALSE),error = function(e){})
+    }
   })
 
   samples <- unique(gsub("_Grn.idat|_Red.idat","",moved.files))


### PR DESCRIPTION
Because of the folder structure (and the previous change, keep.copy=FALSE), if we choose to run (for idat methylation files) GDCprepare several times or if we just run GDCprepare on some samples more than once, on the current state we will have the problem of either keep moving the files up until the base folder (eg. the default "GDCdata") or potentially having some idat files somewhere between the base folder and the file_id folder.

Since "readIDATDNAmethylation" only applies to files that are within the "Raw_intensities" folder anyway, this change makes it so that files that were to be moved outside this folder are not actually moved.

A more elegant solution would be better but this works for now.