### PR TITLE
Fix duplicates issue when querying expression data

### DIFF
--- a/R/prepare.R
+++ b/R/prepare.R
@@ -60,34 +60,53 @@ GDCprepare <- function(
     isServeOK()
     if(missing(query)) stop("Please set query parameter")
 
-    test.duplicated.cases <- (
-        any(
-            duplicated(query$results[[1]]$cases)) & # any duplicated
-            !(query$data.type %in% c(
-                "Clinical data",
-                "Protein expression quantification",
-                "Raw intensities",
-                "Masked Intensities",
-                "Clinical Supplement",
-                "Masked Somatic Mutation",
-                "Biospecimen Supplement"
-            )
-            )
-    )
-
-
-    if(test.duplicated.cases) {
-        dup <- query$results[[1]]$cases[duplicated(query$results[[1]]$cases)]
-        cols <- c("tags","cases","experimental_strategy","analysis_workflow_type")
-        cols <- cols[cols %in% colnames(query$results[[1]])]
-        dup <- query$results[[1]][query$results[[1]]$cases %in% dup,cols]
-        dup <- dup[order(dup$cases),]
-        print(knitr::kable(dup))
-        stop("There are samples duplicated. We will not be able to prepare it")
-    }
+    # test.duplicated.cases <- (
+    #     any(
+    #         duplicated(query$results[[1]]$cases)) & # any duplicated
+    #         !(query$data.type %in% c(
+    #             "Clinical data",
+    #             "Protein expression quantification",
+    #             "Raw intensities",
+    #             "Masked Intensities",
+    #             "Clinical Supplement",
+    #             "Masked Somatic Mutation",
+    #             "Biospecimen Supplement"
+    #         )
+    #         )
+    # )
+    #
+    #
+    # if(test.duplicated.cases) {
+    #     dup <- query$results[[1]]$cases[duplicated(query$results[[1]]$cases)]
+    #     cols <- c("tags","cases","experimental_strategy","analysis_workflow_type")
+    #     cols <- cols[cols %in% colnames(query$results[[1]])]
+    #     dup <- query$results[[1]][query$results[[1]]$cases %in% dup,cols]
+    #     dup <- dup[order(dup$cases),]
+    #     print(knitr::kable(dup))
+    #     stop("There are samples duplicated. We will not be able to prepare it")
+    # }
 
     if (!save & remove.files.prepared) {
         stop("To remove the files, please set save to TRUE. Otherwise, the data will be lost")
+    }
+
+    cases_col <- ifelse(
+        any(grepl("TCGA|TARGET|CGCI-HTMCP-CC|CPTAC-2|BEATAML1.0-COHORT",query$results[[1]]$project %>% unlist())),
+        "cases",
+        "sample.submitter_id"
+    )
+
+    tbl = query$results[[1]]
+    cases = tbl[[cases_col]]
+
+    if (any(duplicated(cases))) {
+        message("Removing duplicated cases (with older updated time)")
+        tbl2 = tbl |> dplyr::arrange(dplyr::desc(tbl$updated_datetime))
+        tbl2 = tbl2[!duplicated(tbl2[[cases_col]]), ]
+        n_dup = nrow(tbl) - nrow(tbl2)
+        query$results[[1]] = tbl2
+        cases = tbl2[[cases_col]]
+        message(" => ", n_dup, " records removed")
     }
 
     # We save the files in project/data.category/data.type/file_id/file_name
@@ -138,11 +157,6 @@ GDCprepare <- function(
         }
     }
 
-    cases <- ifelse(
-        grepl("TCGA|TARGET|CGCI-HTMCP-CC|CPTAC-2|BEATAML1.0-COHORT",query$results[[1]]$project %>% unlist()),
-        query$results[[1]]$cases,
-        query$results[[1]]$sample.submitter_id
-    )
 
     if (grepl("Transcriptome Profiling", query$data.category, ignore.case = TRUE)){
 
@@ -1187,7 +1201,7 @@ colDataPrepare <- function(barcode){
 
     # How to deal with mixed samples "C3N-02003-01;C3N-02003-021" ?
     # Check if this breaks the package
-    if(any(grepl("C3N-|C3L-",barcode))) {
+    if(any(grepl("C3N-|C3L-|CPT",barcode))) {
         ret <- data.frame(
             sample = map(barcode,.f = function(x) stringr::str_split(x,";") %>% unlist) %>% unlist()
         )

--- a/R/prepare.R
+++ b/R/prepare.R
@@ -1445,17 +1445,10 @@ readTranscriptomeProfiling <- function(
       }, .progress = "time")
 
       # bind all counts and then add the gene metadata
-      suppressMessages({
-        df <- x %>%  map_dfc(.f = function(y) y[,4:8])
-        df <- bind_cols(x[[1]][,1:3],df)
-      })
+      if (!missing(cases)) names(x) <- cases
+      df <- data.table::rbindlist(x, use.names = TRUE, idcol = "case_barcode")
+      df <- data.table::dcast(df, gene_id + gene_name + gene_type ~ case_barcode, value.var = colnames(df)[-c(1:4)])
 
-      # Adding barcodes to columns names, if user wants a dataframe
-      if(!missing(cases))  {
-        colnames(df)[-c(1:3)] <- sapply(cases, function(x){
-          stringr::str_c(c("unstranded_","stranded_first_", "stranded_second_","tpm_unstranded_","fpkm_unstranded_"),x)}
-        ) %>% as.character()
-      }
       if(summarizedExperiment) df <- makeSEfromTranscriptomeProfilingSTAR(df,cases,workflow.type)
     }
   } else if(grepl("miRNA", workflow.type, ignore.case = TRUE) & grepl("miRNA", data.type, ignore.case = TRUE)) {

--- a/R/prepare.R
+++ b/R/prepare.R
@@ -1448,6 +1448,7 @@ readTranscriptomeProfiling <- function(
       if (!missing(cases)) names(x) <- cases
       df <- data.table::rbindlist(x, use.names = TRUE, idcol = "case_barcode")
       df <- data.table::dcast(df, gene_id + gene_name + gene_type ~ case_barcode, value.var = colnames(df)[-c(1:4)])
+      df <- dplyr::tibble(df)
 
       if(summarizedExperiment) df <- makeSEfromTranscriptomeProfilingSTAR(df,cases,workflow.type)
     }

--- a/R/prepare.R
+++ b/R/prepare.R
@@ -1204,15 +1204,26 @@ colDataPrepare <- function(barcode){
     # There is a limitation on the size of the string, so this step will be splited in cases of 100
     patient.info <- NULL
 
-    patient.info <- splitAPICall(
+    patient.info <- tryCatch(splitAPICall(
         FUN = getBarcodeInfo,
         step = 10,
         items = ret$sample
-    )
+        ), error = function(e) {
+        message(" => failed")
+        NULL
+    })
 
     if(!is.null(patient.info)) {
         ret$sample_submitter_id <- ret$sample %>% as.character()
         ret <- left_join(ret %>% as.data.frame, patient.info %>% unique, by = "sample_submitter_id")
+    } else {
+        return(
+            data.frame(
+                row.names = barcode,
+                barcode,
+                stringsAsFactors = FALSE
+            )
+        )
     }
     ret$bcr_patient_barcode <- ret$sample %>% as.character()
     ret$sample_submitter_id <- ret$sample %>% as.character()


### PR DESCRIPTION
I was trying to obtain STAR gene expression data from multiple datasets including TCGA, TARGET, and CPTAC. Some errors happened when preparing some projects, and they are mainly related to duplicated records, especially in the `CPTAC-3`. I tested the code and made a workaround. This PR also amended some data checks to make sure the data preparation process went smoothly. 

```
o Preparing output
-------------------
Downloading data for project CPTAC-3
Of the 2340 files for download 2340 already exist.
All samples have been already downloaded
Removing duplicated cases (with older updated time)
 => 41 records removed
```

---

Code to query the data.

```r
library(TCGAbiolinks)
#devtools::load_all("/Volumes/EPan/Repos/TCGAbiolinks/")
#install.packages("/Volumes/EPan/Repos/TCGAbiolinks/", repos = NULL, type = "source")

prjs = TCGAbiolinks::getGDCprojects()
tcga_prjs = prjs$project_id[startsWith(prjs$project_id, "TCGA")]
targ_prjs = prjs$project_id[startsWith(prjs$project_id, "TARGET")]
cpta_prjs = prjs$project_id[startsWith(prjs$project_id, "CPTAC")]

# mRNA pipeline: https://gdc-docs.nci.nih.gov/Data/Bioinformatics_Pipelines/Expression_mRNA_Pipeline/

dir.create("data")
dir.create("data/count")
dir.create("data/tpm")

# GDC data download and prepare ------------------------------------------------

for (i in c(tcga_prjs, targ_prjs, cpta_prjs)) {
  message("Handling ", i)
  # if (file.exists(glue::glue("data/tpm/{i}.exp.tpm.rds"))) {
  #   message("handled already, skipping...")
  #   next()
  # }
  query.exp.hg38 <- GDCquery(
    project = i,
    data.category = "Transcriptome Profiling",
    data.type = "Gene Expression Quantification",
    workflow.type = "STAR - Counts"
  )

  GDCdownload(query.exp.hg38)
  #debug(GDCprepare)
  #debug(readTranscriptomeProfiling)
  #debug(colDataPrepare)
  expdat <- GDCprepare(
    query = query.exp.hg38
  )
  gc()

  message("saving...")
  saveRDS(SummarizedExperiment::assays(expdat)[["unstranded"]], file = glue::glue("data/count/{i}.exp.count.rds"))
  saveRDS(SummarizedExperiment::assays(expdat)[["tpm_unstrand"]], file = glue::glue("data/tpm/{i}.exp.tpm.rds"))
  message("done")
  gc()
}
```