### PR TITLE
Added handling of missing disease response column for TCGA-LAML

### DIFF
--- a/R/prepare.R
+++ b/R/prepare.R
@@ -1184,7 +1184,7 @@ colDataPrepare <- function(barcode){
     if(all(grepl("TARGET",barcode))) ret <- colDataPrepareTARGET(barcode)
     if(all(grepl("TCGA",barcode))) ret <- colDataPrepareTCGA(barcode)
     if(all(grepl("MMRF",barcode))) ret <- colDataPrepareMMRF(barcode)
-        
+
     # How to deal with mixed samples "C3N-02003-01;C3N-02003-021" ?
     # Check if this breaks the package
     if(any(grepl("C3N-|C3L-",barcode))) {
@@ -1194,8 +1194,8 @@ colDataPrepare <- function(barcode){
     }
 
     # Deal with BEATAML samples beginning with "aq-"
-    barcode <- ifelse(substr(barcode, 1, 3) == "aq-", substr(barcode, 4, 10), barcode) 
-                
+    barcode <- ifelse(substr(barcode, 1, 3) == "aq-", substr(barcode, 4, 10), barcode)
+
     if(is.null(ret)) {
         ret <- data.frame(
             sample = barcode %>% unique,
@@ -1914,7 +1914,7 @@ getBarcodeInfo <- function(barcode) {
         diagnoses <- rbindlist(lapply(results$diagnoses, function(x) if(is.null(x)) data.frame(NA) else x),fill = TRUE)
         diagnoses[,c("updated_datetime","created_datetime","state","days_to_last_follow_up")] <- NULL
         if(any(grepl("submitter_id", colnames(diagnoses)))) {
-            diagnoses$diagnosis_id <- diagnoses$submitter_id 
+            diagnoses$diagnosis_id <- diagnoses$submitter_id
             diagnoses$submitter_id <- gsub("-diagnosis|_diagnosis.*|-DIAG|diag-","", diagnoses$submitter_id)
         }  else {
             diagnoses$submitter_id <- submitter_id
@@ -1971,7 +1971,7 @@ getBarcodeInfo <- function(barcode) {
         follow_ups[,c("updated_datetime","created_datetime","state")] <- NULL
         if (any(grepl("submitter_id", colnames(follow_ups)))) {
             follow_ups$submitter_id <- gsub("_follow_up.*","", follow_ups$submitter_id)
-            if(is.null(follow_ups$submitter_id)){follow_ups$submitter_id <- NA}
+            if(is.null(follow_ups$disease_response)){follow_ups$disease_response <- NA}
             follow_ups_last <- follow_ups %>%
                 dplyr::select(
                     c(
@@ -2066,7 +2066,7 @@ getBarcodeInfo <- function(barcode) {
 
 
     if(any(substr(barcode,1,str_length(df$submitter_id)) %in% df$submitter_id)){
-        #Multiple diagnoses result in multiple rows. This sorting retains the primary diagnosis. 
+        #Multiple diagnoses result in multiple rows. This sorting retains the primary diagnosis.
         if(is.data.frame(df)&&!is.null(df$diagnosis_id)){
             df <- df[order(df$sample_submitter_id,df$diagnosis_id),]
             df$diagnosis_id <- NULL

--- a/R/prepare.R
+++ b/R/prepare.R
@@ -1971,6 +1971,7 @@ getBarcodeInfo <- function(barcode) {
         follow_ups[,c("updated_datetime","created_datetime","state")] <- NULL
         if (any(grepl("submitter_id", colnames(follow_ups)))) {
             follow_ups$submitter_id <- gsub("_follow_up.*","", follow_ups$submitter_id)
+            if(is.null(follow_ups$submitter_id)){follow_ups$submitter_id <- NA}
             follow_ups_last <- follow_ups %>%
                 dplyr::select(
                     c(


### PR DESCRIPTION
For the peripheral blood STAR-Count files associated with the TCGA-LAML project, a column named "disease_response" was missing from the "follow_ups" data.frame that is produced from results$follow_ups within the getBarcodeInfo function. This absence resulted in dplyr::select function producing an error when working with data from that project.

A line of code testing for a null value in this column, and if detected, filling it with NA values was added.